### PR TITLE
Add public scope to HttpStatusAdapter

### DIFF
--- a/src/main/java/org/zalando/problem/spring/web/advice/HttpStatusAdapter.java
+++ b/src/main/java/org/zalando/problem/spring/web/advice/HttpStatusAdapter.java
@@ -29,11 +29,11 @@ import javax.ws.rs.core.Response.Status.Family;
 /**
  * An implementation of {@link javax.ws.rs.core.Response.StatusType} to map {@link HttpStatus}.
  */
-class HttpStatusAdapter implements Response.StatusType {
+public class HttpStatusAdapter implements Response.StatusType {
 
     private final HttpStatus status;
 
-    HttpStatusAdapter(HttpStatus status) {
+    public HttpStatusAdapter(HttpStatus status) {
         this.status = status;
     }
 


### PR DESCRIPTION
I didn't not touch `toStatus` because is part of public API. Are you ok with that?

Should closes #53 