### PR TITLE
Ability to provide custom response in case client does not accept json.

### DIFF
--- a/src/main/java/org/zalando/problem/spring/web/advice/AdviceTrait.java
+++ b/src/main/java/org/zalando/problem/spring/web/advice/AdviceTrait.java
@@ -157,9 +157,13 @@ public interface AdviceTrait {
                     .headers(headers)
                     .contentType(contentType)
                     .body(problem);
-        }).orElseGet(() ->
-                ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).body(null)));
+        }).orElseGet(() -> fallback(throwable, problem, request, headers)));
 
+    }
+
+    default ResponseEntity<Problem> fallback(final Throwable throwable, final Problem problem,
+                                             final NativeWebRequest request, final HttpHeaders headers) {
+        return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).body(null);
     }
 
     default Optional<MediaType> negotiate(final NativeWebRequest request) throws HttpMediaTypeNotAcceptableException {

--- a/src/test/java/org/zalando/problem/spring/web/advice/AdviceTraitTest.java
+++ b/src/test/java/org/zalando/problem/spring/web/advice/AdviceTraitTest.java
@@ -160,7 +160,7 @@ public class AdviceTraitTest {
         assertThat(nullPointer.getCause(), is(nullValue()));
     }
 
-    public String method(String s) {
+    private String method(String s) {
         return "org.zalando.problem.spring.web.advice.AdviceTraitTest." + s;
     }
 

--- a/src/test/java/org/zalando/problem/spring/web/advice/FallbackTest.java
+++ b/src/test/java/org/zalando/problem/spring/web/advice/FallbackTest.java
@@ -1,0 +1,69 @@
+package org.zalando.problem.spring.web.advice;
+
+/*
+ * #%L
+ * problem-handling
+ * %%
+ * Copyright (C) 2015 Zalando SE
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.zalando.problem.Problem;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+public final class FallbackTest implements AdviceTraitTesting {
+
+    @Override
+    public Object unit() {
+        return new FallbackProblemHandling();
+    }
+
+    @Test
+    public void customFallbackUsed() throws Exception {
+        mvc().perform(request(GET, "http://localhost/api/handler-problem")
+                .accept("text/html"))
+                .andExpect(status().isConflict())
+                .andExpect(content().string(""))
+                .andExpect(header().doesNotExist("Content-Type"))
+                .andExpect(header().string("X-Fallback-Used", is("true")));
+    }
+
+    @ControllerAdvice
+    private static class FallbackProblemHandling implements ProblemHandling {
+
+        @Override
+        public ResponseEntity<Problem> fallback(final Throwable throwable, final Problem problem,
+                                                final NativeWebRequest request,
+                                                final HttpHeaders headers) {
+            return ResponseEntity
+                    .status(problem.getStatus().getStatusCode())
+                    .header("X-Fallback-Used", Boolean.toString(true))
+                    .body(null);
+        }
+
+    }
+
+
+}

--- a/src/test/java/org/zalando/problem/spring/web/advice/FallbackTest.java
+++ b/src/test/java/org/zalando/problem/spring/web/advice/FallbackTest.java
@@ -65,5 +65,4 @@ public final class FallbackTest implements AdviceTraitTesting {
 
     }
 
-
 }


### PR DESCRIPTION
Currently if client doesn't accept json he will get **HTTP 406** back and original response code will be lost. The alternative may be to return original HTTP code, but without the body. Currently the only way to achieve such a behaviour is to override _create_ method, but it leads to unnecessary code duplication and possible problems in the future (when library code changes). What do you think about extracting fallback logic into a separate method and giving the user an ability to get access to original parameters (throwable, request, ...)?

PS. Our use case was the following. Client relies on _HTTP 404_. does not care about the body in this case, and expects _text/html_. If entity was not found client gets 406 instead of 404.  