### PR TITLE
Hide objectName if possible

### DIFF
--- a/src/main/java/org/zalando/problem/spring/web/advice/validation/BaseBindingResultAdviceTrait.java
+++ b/src/main/java/org/zalando/problem/spring/web/advice/validation/BaseBindingResultAdviceTrait.java
@@ -12,8 +12,8 @@ import static java.util.stream.Collectors.toList;
 public interface BaseBindingResultAdviceTrait extends BaseValidationAdviceTrait {
 
     default Violation createViolation(final FieldError error) {
-        final String fieldName = error.getObjectName() + "." + error.getField();
-        return new Violation(formatFieldName(fieldName), error.getDefaultMessage());
+        final String fieldName = formatFieldName(error.getField());
+        return new Violation(fieldName, error.getDefaultMessage());
     }
 
     default Violation createViolation(final ObjectError error) {

--- a/src/test/java/org/zalando/problem/spring/web/advice/validation/BindAdviceTraitTest.java
+++ b/src/test/java/org/zalando/problem/spring/web/advice/validation/BindAdviceTraitTest.java
@@ -21,9 +21,9 @@ public class BindAdviceTraitTest implements AdviceTraitTesting {
              .andExpect(jsonPath("$.title", is("Constraint Violation")))
              .andExpect(jsonPath("$.status", is(400)))
              .andExpect(jsonPath("$.violations", hasSize(2)))
-             .andExpect(jsonPath("$.violations[0].field", is("page_request.page")))
+             .andExpect(jsonPath("$.violations[0].field", is("page")))
              .andExpect(jsonPath("$.violations[0].message", is("must be greater than or equal to 0")))
-             .andExpect(jsonPath("$.violations[1].field", is("page_request.size")))
+             .andExpect(jsonPath("$.violations[1].field", is("size")))
              .andExpect(jsonPath("$.violations[1].message", is("must be greater than or equal to 1")));
     }
 }

--- a/src/test/java/org/zalando/problem/spring/web/advice/validation/MethodArgumentNotValidAdviceTraitTest.java
+++ b/src/test/java/org/zalando/problem/spring/web/advice/validation/MethodArgumentNotValidAdviceTraitTest.java
@@ -25,7 +25,7 @@ public final class MethodArgumentNotValidAdviceTraitTest implements AdviceTraitT
                 .andExpect(jsonPath("$.title", is("Constraint Violation")))
                 .andExpect(jsonPath("$.status", is(400)))
                 .andExpect(jsonPath("$.violations", hasSize(1)))
-                .andExpect(jsonPath("$.violations[0].field", is("user_request.name")))
+                .andExpect(jsonPath("$.violations[0].field", is("name")))
                 .andExpect(jsonPath("$.violations[0].message", startsWith("size must be between 3 and 10")));
     }
 


### PR DESCRIPTION
In order to do not leak internal Java object name, we remove `error.getObjectName` from field generation.

fixes #86