### PR TITLE
Split toProblem method for easy customization

### DIFF
--- a/src/main/java/org/zalando/problem/spring/web/advice/AdviceTrait.java
+++ b/src/main/java/org/zalando/problem/spring/web/advice/AdviceTrait.java
@@ -134,19 +134,8 @@ public interface AdviceTrait {
         return Optional.of(candidate.code());
     }
 
-    default ThrowableProblem toProblem(final Throwable throwable, final StatusType status) {
-        return toProblem(throwable, status, Problem.DEFAULT_TYPE);
-    }
-
-    default ThrowableProblem toProblem(final Throwable throwable, final StatusType status, final URI type) {
+    default StackTraceElement[] createStackTrace(final ProblemBuilder builder, final Throwable throwable) {
         final Throwable cause = throwable.getCause();
-
-        final ProblemBuilder builder = Problem.builder()
-                .withType(type)
-                .withTitle(status.getReasonPhrase())
-                .withStatus(status)
-                .withDetail(throwable.getMessage());
-
         final StackTraceElement[] stackTrace;
 
         if (cause == null || !isCausalChainsEnabled()) {
@@ -162,9 +151,28 @@ public interface AdviceTrait {
             System.arraycopy(current, 0, stackTrace, 0, length);
         }
 
+        return stackTrace;
+    }
+
+    default ThrowableProblem toProblem(final Throwable throwable, final StatusType status) {
+        return toProblem(throwable, status, Problem.DEFAULT_TYPE);
+    }
+
+    default ThrowableProblem toProblem(final Throwable throwable, final StatusType status, final URI type) {
+        final ProblemBuilder builder = newInitializedProblemBuilder(throwable, status, type);
+        final StackTraceElement[] stackTrace = createStackTrace(builder, throwable);
         final ThrowableProblem problem = builder.build();
+
         problem.setStackTrace(stackTrace);
         return problem;
+    }
+
+    default ProblemBuilder newInitializedProblemBuilder(final Throwable throwable, final StatusType status, final URI type) {
+        return Problem.builder()
+                .withType(type)
+                .withTitle(status.getReasonPhrase())
+                .withStatus(status)
+                .withDetail(throwable.getMessage());
     }
 
     default boolean isCausalChainsEnabled() {


### PR DESCRIPTION
Same approach as:

https://github.com/zalando/problem-spring-web/blob/5d7eed5da9f272e4b2e6ce8e36a3c5175b2c0daa/src/main/java/org/zalando/problem/spring/web/advice/validation/BaseValidationAdviceTrait.java#L37-L51

Now it is possible to override "newInitializedProblemBuilder" for problem customization.