### PR TITLE
Add a code field to the Validation DTO

### DIFF
--- a/src/main/java/org/zalando/problem/spring/web/advice/validation/BaseBindingResultAdviceTrait.java
+++ b/src/main/java/org/zalando/problem/spring/web/advice/validation/BaseBindingResultAdviceTrait.java
@@ -13,12 +13,12 @@ public interface BaseBindingResultAdviceTrait extends BaseValidationAdviceTrait 
 
     default Violation createViolation(final FieldError error) {
         final String fieldName = formatFieldName(error.getField());
-        return new Violation(fieldName, error.getDefaultMessage());
+        return new Violation(fieldName, error.getDefaultMessage(), error.getCode());
     }
 
     default Violation createViolation(final ObjectError error) {
         final String fieldName = formatFieldName(error.getObjectName());
-        return new Violation(fieldName, error.getDefaultMessage());
+        return new Violation(fieldName, error.getDefaultMessage(), error.getCode());
     }
 
     default List<Violation> createViolations(final BindingResult result) {

--- a/src/main/java/org/zalando/problem/spring/web/advice/validation/BaseValidationAdviceTrait.java
+++ b/src/main/java/org/zalando/problem/spring/web/advice/validation/BaseValidationAdviceTrait.java
@@ -42,7 +42,7 @@ interface BaseValidationAdviceTrait extends AdviceTrait {
 
         final List<Violation> violations = stream.stream()
             // sorting to make tests deterministic
-            .sorted(comparing(Violation::getField).thenComparing(Violation::getMessage))
+            .sorted(comparing(Violation::getField).thenComparing(Violation::getMessage).thenComparing(Violation::getCode))
             .collect(toList());
 
         final Problem problem = new ConstraintViolationProblem(type, status, violations);

--- a/src/main/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationAdviceTrait.java
+++ b/src/main/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationAdviceTrait.java
@@ -21,7 +21,7 @@ import static java.util.stream.Collectors.toList;
 public interface ConstraintViolationAdviceTrait extends BaseValidationAdviceTrait {
 
     default Violation createViolation(final ConstraintViolation violation) {
-        return new Violation(formatFieldName(violation.getPropertyPath().toString()), violation.getMessage());
+        return new Violation(formatFieldName(violation.getPropertyPath().toString()), violation.getMessage(), null);
     }
 
     @ExceptionHandler

--- a/src/main/java/org/zalando/problem/spring/web/advice/validation/Violation.java
+++ b/src/main/java/org/zalando/problem/spring/web/advice/validation/Violation.java
@@ -1,5 +1,6 @@
 package org.zalando.problem.spring.web.advice.validation;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -7,10 +8,12 @@ public final class Violation {
 
     private final String field;
     private final String message;
+    private final String code;
 
-    public Violation(final String field, final String message) {
+    public Violation(final String field, final String message, final @Nullable String code) {
         this.field = field;
         this.message = message;
+        this.code = code;
     }
 
     public String getField() {
@@ -21,4 +24,7 @@ public final class Violation {
         return message;
     }
 
+    public String getCode() {
+        return code;
+    }
 }

--- a/src/main/java/org/zalando/problem/validation/ViolationMixIn.java
+++ b/src/main/java/org/zalando/problem/validation/ViolationMixIn.java
@@ -10,4 +10,7 @@ public interface ViolationMixIn {
 
     @JsonProperty("message")
     String getMessage();
+
+    @JsonProperty("code")
+    String getCode();
 }

--- a/src/test/java/org/zalando/problem/spring/web/advice/validation/BindAdviceTraitTest.java
+++ b/src/test/java/org/zalando/problem/spring/web/advice/validation/BindAdviceTraitTest.java
@@ -24,8 +24,10 @@ final class BindAdviceTraitTest implements AdviceTraitTesting {
              .andExpect(jsonPath("$.violations", hasSize(2)))
              .andExpect(jsonPath("$.violations[0].field", is("page")))
              .andExpect(jsonPath("$.violations[0].message", is("must be greater than or equal to 0")))
+             .andExpect(jsonPath("$.violations[0].code", is("Min")))
              .andExpect(jsonPath("$.violations[1].field", is("size")))
-             .andExpect(jsonPath("$.violations[1].message", is("must be greater than or equal to 1")));
+             .andExpect(jsonPath("$.violations[1].message", is("must be greater than or equal to 1")))
+             .andExpect(jsonPath("$.violations[1].code", is("Min")));
     }
 
 }

--- a/src/test/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationAdviceTraitTest.java
+++ b/src/test/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationAdviceTraitTest.java
@@ -5,6 +5,7 @@ import org.zalando.problem.spring.web.advice.AdviceTraitTesting;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -25,7 +26,8 @@ final class ConstraintViolationAdviceTraitTest implements AdviceTraitTesting {
                 .andExpect(jsonPath("$.status", is(400)))
                 .andExpect(jsonPath("$.violations", hasSize(1)))
                 .andExpect(jsonPath("$.violations[0].field", is(""))) // field is not set when validation manually
-                .andExpect(jsonPath("$.violations[0].message", is("must not be called Bob")));
+                .andExpect(jsonPath("$.violations[0].message", is("must not be called Bob")))
+                .andExpect(jsonPath("$.violations[0].code", nullValue()));
     }
 
 }

--- a/src/test/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationProblemModuleTest.java
+++ b/src/test/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationProblemModuleTest.java
@@ -30,7 +30,7 @@ final class ConstraintViolationProblemModuleTest {
                 .registerModule(new ProblemModule())
                 .registerModule(new ConstraintViolationProblemModule());
 
-        final Violation violation = new Violation("bob", "was missing");
+        final Violation violation = new Violation("bob", "was missing", "missing code");
         final ConstraintViolationProblem unit = new ConstraintViolationProblem(BAD_REQUEST, singletonList(violation));
 
         with(mapper.writeValueAsString(unit))
@@ -39,7 +39,8 @@ final class ConstraintViolationProblemModuleTest {
                 .assertThat("title", is("Constraint Violation"))
                 .assertThat("violations", hasSize(1))
                 .assertThat("violations.*.field", contains("bob"))
-                .assertThat("violations.*.message", contains("was missing"));
+                .assertThat("violations.*.message", contains("was missing"))
+                .assertThat("violations.*.code", contains("missing code"));
     }
 
     @Test

--- a/src/test/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationProblemTest.java
+++ b/src/test/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationProblemTest.java
@@ -14,7 +14,7 @@ public class ConstraintViolationProblemTest {
     @Test
     public void shouldCreateCopyOfViolations(){
         final List<Violation> violations = new ArrayList<>();
-        violations.add(new Violation("x", "y"));
+        violations.add(new Violation("x", "y", "z"));
 
         final ConstraintViolationProblem problem = new ConstraintViolationProblem(BAD_REQUEST, violations);
 

--- a/src/test/java/org/zalando/problem/spring/web/advice/validation/MethodArgumentNotValidAdviceTraitTest.java
+++ b/src/test/java/org/zalando/problem/spring/web/advice/validation/MethodArgumentNotValidAdviceTraitTest.java
@@ -26,7 +26,8 @@ final class MethodArgumentNotValidAdviceTraitTest implements AdviceTraitTesting 
                 .andExpect(jsonPath("$.status", is(400)))
                 .andExpect(jsonPath("$.violations", hasSize(1)))
                 .andExpect(jsonPath("$.violations[0].field", is("name")))
-                .andExpect(jsonPath("$.violations[0].message", startsWith("size must be between 3 and 10")));
+                .andExpect(jsonPath("$.violations[0].message", startsWith("size must be between 3 and 10")))
+                .andExpect(jsonPath("$.violations[0].code", is("Size")));
     }
 
     @Test
@@ -41,7 +42,8 @@ final class MethodArgumentNotValidAdviceTraitTest implements AdviceTraitTesting 
                 .andExpect(jsonPath("$.status", is(400)))
                 .andExpect(jsonPath("$.violations", hasSize(1)))
                 .andExpect(jsonPath("$.violations[0].field", is("user_request")))
-                .andExpect(jsonPath("$.violations[0].message", is("must not be called Bob")));
+                .andExpect(jsonPath("$.violations[0].message", is("must not be called Bob")))
+                .andExpect(jsonPath("$.violations[0].code", is("NotBob")));
     }
 
 }


### PR DESCRIPTION
The "code" field of BindingResult can be useful for some clients (eg. for translation)