### PR TITLE
add 'codes' field to Violation

### DIFF
--- a/src/main/java/org/zalando/problem/spring/web/advice/validation/BaseBindingResultAdviceTrait.java
+++ b/src/main/java/org/zalando/problem/spring/web/advice/validation/BaseBindingResultAdviceTrait.java
@@ -5,6 +5,8 @@ import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 
 import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
@@ -13,12 +15,12 @@ public interface BaseBindingResultAdviceTrait extends BaseValidationAdviceTrait 
 
     default Violation createViolation(final FieldError error) {
         final String fieldName = formatFieldName(error.getField());
-        return new Violation(fieldName, error.getDefaultMessage());
+        return new Violation(fieldName,error.getCodes(),error.getDefaultMessage());
     }
 
     default Violation createViolation(final ObjectError error) {
         final String fieldName = formatFieldName(error.getObjectName());
-        return new Violation(fieldName, error.getDefaultMessage());
+        return new Violation(fieldName,error.getCodes(), error.getDefaultMessage());
     }
 
     default List<Violation> createViolations(final BindingResult result) {

--- a/src/main/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationAdviceTrait.java
+++ b/src/main/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationAdviceTrait.java
@@ -21,7 +21,7 @@ import static java.util.stream.Collectors.toList;
 public interface ConstraintViolationAdviceTrait extends BaseValidationAdviceTrait {
 
     default Violation createViolation(final ConstraintViolation violation) {
-        return new Violation(formatFieldName(violation.getPropertyPath().toString()), violation.getMessage());
+        return new Violation(formatFieldName(violation.getPropertyPath().toString()), new String[]{violation.getConstraintDescriptor().getAnnotation().toString()}, violation.getMessage());
     }
 
     @ExceptionHandler

--- a/src/main/java/org/zalando/problem/spring/web/advice/validation/Violation.java
+++ b/src/main/java/org/zalando/problem/spring/web/advice/validation/Violation.java
@@ -7,10 +7,13 @@ public final class Violation {
 
     private final String field;
     private final String message;
+    private String[] codes = {};
 
-    public Violation(final String field, final String message) {
+
+    public Violation(final String field, String[] codes, final String message) {
         this.field = field;
         this.message = message;
+        this.codes = codes;
     }
 
     public String getField() {
@@ -21,4 +24,7 @@ public final class Violation {
         return message;
     }
 
+    public String[] getCodes() {
+        return codes;
+    }
 }

--- a/src/main/java/org/zalando/problem/validation/ViolationMixIn.java
+++ b/src/main/java/org/zalando/problem/validation/ViolationMixIn.java
@@ -10,4 +10,7 @@ public interface ViolationMixIn {
 
     @JsonProperty("message")
     String getMessage();
+
+    @JsonProperty("codes")
+    String[] getCodes();
 }

--- a/src/test/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationProblemModuleTest.java
+++ b/src/test/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationProblemModuleTest.java
@@ -13,9 +13,8 @@ import java.net.URI;
 import static com.jayway.jsonassert.JsonAssert.with;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 import static org.zalando.problem.Status.BAD_REQUEST;
 
 @Slf4j
@@ -30,15 +29,16 @@ final class ConstraintViolationProblemModuleTest {
                 .registerModule(new ProblemModule())
                 .registerModule(new ConstraintViolationProblemModule());
 
-        final Violation violation = new Violation("bob", "was missing");
+        final Violation violation = new Violation("bob",new String[]{"NotEmpty"}, "was missing");
         final ConstraintViolationProblem unit = new ConstraintViolationProblem(BAD_REQUEST, singletonList(violation));
-
+        System.out.println(mapper.writeValueAsString(unit));
         with(mapper.writeValueAsString(unit))
                 .assertThat("status", is(400))
                 .assertThat("type", is(ConstraintViolationProblem.TYPE_VALUE))
                 .assertThat("title", is("Constraint Violation"))
                 .assertThat("violations", hasSize(1))
                 .assertThat("violations.*.field", contains("bob"))
+                .assertThat("violations.*.codes.*", contains("NotEmpty"))
                 .assertThat("violations.*.message", contains("was missing"));
     }
 

--- a/src/test/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationProblemTest.java
+++ b/src/test/java/org/zalando/problem/spring/web/advice/validation/ConstraintViolationProblemTest.java
@@ -14,7 +14,7 @@ public class ConstraintViolationProblemTest {
     @Test
     public void shouldCreateCopyOfViolations(){
         final List<Violation> violations = new ArrayList<>();
-        violations.add(new Violation("x", "y"));
+        violations.add(new Violation("x",new String[]{"NotEmpty"}, "y"));
 
         final ConstraintViolationProblem problem = new ConstraintViolationProblem(BAD_REQUEST, violations);
 


### PR DESCRIPTION
violation contains only 'field' and 'messages' not suffice for client. e.g. we may put many class level validation constraint annotation to bean class but we can't determine particular message come from which annotation.