### PR TITLE
Fix logger's name

### DIFF
--- a/problem-spring-common/src/main/java/org/zalando/problem/spring/common/AdviceTraits.java
+++ b/problem-spring-common/src/main/java/org/zalando/problem/spring/common/AdviceTraits.java
@@ -21,7 +21,7 @@ import static org.zalando.problem.spring.common.MediaTypes.X_PROBLEM;
 @API(status = INTERNAL)
 public final class AdviceTraits {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AdviceTrait.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AdviceTraits.class);
 
     private AdviceTraits() {
 

--- a/problem-spring-common/src/test/java/org/zalando/problem/spring/common/AdviceTraitsTest.java
+++ b/problem-spring-common/src/test/java/org/zalando/problem/spring/common/AdviceTraitsTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 final class AdviceTraitsTest {
 
-    private final TestLogger log = TestLoggerFactory.getTestLogger(AdviceTrait.class);
+    private final TestLogger log = TestLoggerFactory.getTestLogger(AdviceTraits.class);
 
     @BeforeEach
     @AfterEach


### PR DESCRIPTION
## Description
Logger's name within `AdviceTraits` was using a name of another class:
`AdviceTrait` (note missing `s` at the end).

## Motivation and Context
Having invalid logger name makes getting to the place, where something was logged quite challenging. I started checking `AdviceTrait` class to see how the logging code looks like, but wasn't able to find any logging there :)

Issue was created here: https://github.com/zalando/problem-spring-web/issues/298

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
