### PR TITLE
Added support for Retry-After based on circuit breaker delay

### DIFF
--- a/problem-spring-web/src/main/java/org/zalando/problem/spring/web/advice/network/CircuitBreakerOpenAdviceTrait.java
+++ b/problem-spring-web/src/main/java/org/zalando/problem/spring/web/advice/network/CircuitBreakerOpenAdviceTrait.java
@@ -2,12 +2,15 @@ package org.zalando.problem.spring.web.advice.network;
 
 import net.jodah.failsafe.CircuitBreakerOpenException;
 import org.apiguardian.api.API;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
 import org.zalando.problem.spring.web.advice.AdviceTrait;
+
+import java.time.Duration;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
@@ -20,7 +23,16 @@ public interface CircuitBreakerOpenAdviceTrait extends AdviceTrait {
     default ResponseEntity<Problem> handleCircuitBreakerOpen(
             final CircuitBreakerOpenException exception,
             final NativeWebRequest request) {
-        return create(Status.SERVICE_UNAVAILABLE, exception, request);
+
+        final Duration delay = exception.getCircuitBreaker().getDelay();
+        final HttpHeaders headers = retryAfter(delay.getSeconds());
+        return create(Status.SERVICE_UNAVAILABLE, exception, request, headers);
+    }
+
+    default HttpHeaders retryAfter(final long delay) {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.RETRY_AFTER, String.valueOf(delay));
+        return headers;
     }
 
 }

--- a/problem-spring-web/src/test/java/org/zalando/problem/spring/web/advice/network/CircuitBreakerOpenAdviceTraitTest.java
+++ b/problem-spring-web/src/test/java/org/zalando/problem/spring/web/advice/network/CircuitBreakerOpenAdviceTraitTest.java
@@ -19,6 +19,7 @@ final class CircuitBreakerOpenAdviceTraitTest implements AdviceTraitTesting {
         mvc().perform(request(GET, "http://localhost/api/handler-circuit-breaker-open"))
                 .andExpect(status().isServiceUnavailable())
                 .andExpect(header().string("Content-Type", is("application/problem+json")))
+                .andExpect(header().longValue("Retry-After", 60))
                 .andExpect(jsonPath("$.type").doesNotExist())
                 .andExpect(jsonPath("$.title", is("Service Unavailable")))
                 .andExpect(jsonPath("$.status", is(503)))

--- a/problem-spring-webflux/src/main/java/org/zalando/problem/spring/webflux/advice/network/CircuitBreakerOpenAdviceTrait.java
+++ b/problem-spring-webflux/src/main/java/org/zalando/problem/spring/webflux/advice/network/CircuitBreakerOpenAdviceTrait.java
@@ -2,6 +2,7 @@ package org.zalando.problem.spring.webflux.advice.network;
 
 import net.jodah.failsafe.CircuitBreakerOpenException;
 import org.apiguardian.api.API;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.server.ServerWebExchange;
@@ -9,6 +10,8 @@ import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
 import org.zalando.problem.spring.webflux.advice.AdviceTrait;
 import reactor.core.publisher.Mono;
+
+import java.time.Duration;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.INTERNAL;
@@ -21,7 +24,16 @@ public interface CircuitBreakerOpenAdviceTrait extends AdviceTrait {
     default Mono<ResponseEntity<Problem>> handleCircuitBreakerOpen(
             final CircuitBreakerOpenException exception,
             final ServerWebExchange request) {
-        return create(Status.SERVICE_UNAVAILABLE, exception, request);
+
+        final Duration delay = exception.getCircuitBreaker().getDelay();
+        final HttpHeaders headers = retryAfter(delay.getSeconds());
+        return create(Status.SERVICE_UNAVAILABLE, exception, request, headers);
+    }
+
+    default HttpHeaders retryAfter(final long delay) {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.RETRY_AFTER, String.valueOf(delay));
+        return headers;
     }
 
 }

--- a/problem-spring-webflux/src/test/java/org/zalando/problem/spring/webflux/advice/network/CircuitBreakerOpenAdviceTraitTest.java
+++ b/problem-spring-webflux/src/test/java/org/zalando/problem/spring/webflux/advice/network/CircuitBreakerOpenAdviceTraitTest.java
@@ -12,6 +12,7 @@ import org.zalando.problem.spring.webflux.advice.ProblemHandling;
 import javax.annotation.Nullable;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -23,6 +24,7 @@ class CircuitBreakerOpenAdviceTraitTest implements AdviceTraitTesting {
                 .exchange()
                 .expectStatus().isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
                 .expectHeader().contentType(MediaTypes.PROBLEM)
+                .expectHeader().value("Retry-After", equalTo("60"))
                 .expectBody(Problem.class).returnResult().getResponseBody();
 
         assertNotNull(problem);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A `CircuitBreakerOpenException` provides access to the circuit breaker and its configured delay. That delay is now exposed as `Retry-After` header to clients.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #265 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
