### PR TITLE
Added service definition file to load Jackson module automatically

### DIFF
--- a/problem-violations/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
+++ b/problem-violations/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
@@ -1,0 +1,1 @@
+org.zalando.problem.violations.ConstraintViolationProblemModule


### PR DESCRIPTION
Maybe it was intended that the `problem-validations` module was missing the file so that Jackson picks it up without registering it manually by whatever means.

## Motivation and Context
As the problem library itself is also using this feature, it makes sense to provide the same convenience also for this library.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- ~[ ] My change requires a change to the documentation.~
- ~[ ] I have updated the documentation accordingly.~
- ~[ ] I have added tests to cover my changes.~
