### PR TITLE
Don't use default order for spring-security configurer

### DIFF
--- a/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/SecurityConfiguration.java
+++ b/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/SecurityConfiguration.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
@@ -14,6 +16,7 @@ import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
 @Configuration
 @ConditionalOnClass(WebSecurityConfigurerAdapter.class) //only when spring-security is in classpath
 @Import(SecurityProblemSupport.class)
+@Order(Ordered.LOWEST_PRECEDENCE - 21)
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Autowired
     private SecurityProblemSupport problemSupport;

--- a/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/SecurityConfiguration.java
+++ b/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/SecurityConfiguration.java
@@ -16,7 +16,7 @@ import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
 @Configuration
 @ConditionalOnClass(WebSecurityConfigurerAdapter.class) //only when spring-security is in classpath
 @Import(SecurityProblemSupport.class)
-@Order(Ordered.LOWEST_PRECEDENCE - 21)
+@Order(Ordered.LOWEST_PRECEDENCE - 21) //subtract random, uncommon number to reduce chances of collision with a user-selected order
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Autowired
     private SecurityProblemSupport problemSupport;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is an improvement to reduce the chances of collision with users of the library that are also using spring-security's WebSecurityConfigurer

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If you have your own WebSecurityConfigurerAdapter without a defined `@Order`, spring will assign it the default order of 100. In the current version of problem-spring-web-autoconfigurer, there is no order specified, which means that it is also set to 100. Since the order of the config has to be unique, this leads to the following error when starting the app:

```
Injection of autowired dependencies failed; nested exception is java.lang.IllegalStateException: @Order on WebSecurityConfigurers must be unique. Order of 100 was already used on com.foo.SecurityConfig$$EnhancerBySpringCGLIB$$362d55eb@4cae887e, so it cannot be used on org.zalando.problem.spring.web.autoconfigure.security.SecurityConfiguration$$EnhancerBySpringCGLIB$$5b30aee1@616c667d too.
```
I gave it a low priority on purpose so as to give the user the chance to overwrite the configuration even for the Problem library, but I subtracted a random factor in the priority since just giving it `Ordered.LOWEST_PRECEDENCE` was still likely to collide with a user's security config
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
