### PR TITLE
Set a fixed locale for the tests

### DIFF
--- a/problem-spring-web/src/test/java/org/zalando/problem/spring/web/advice/security/SecurityAdviceTraitTest.java
+++ b/problem-spring-web/src/test/java/org/zalando/problem/spring/web/advice/security/SecurityAdviceTraitTest.java
@@ -1,12 +1,15 @@
 package org.zalando.problem.spring.web.advice.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -29,6 +32,7 @@ import org.zalando.problem.spring.common.MediaTypes;
 import org.zalando.problem.spring.web.advice.ProblemHandling;
 
 import java.util.List;
+import java.util.Locale;
 
 import static org.hamcrest.Matchers.is;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.anonymous;
@@ -45,12 +49,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebAppConfiguration
 final class SecurityAdviceTraitTest {
 
+    @BeforeEach
+    void setUp() {
+        LocaleContextHolder.setLocale(Locale.ENGLISH);
+    }
+
+    @AfterEach
+    void tearDown() {
+        LocaleContextHolder.resetLocaleContext();
+    }
+
     @Configuration
     @EnableWebMvc
     @EnableWebSecurity
     @Import({MvcConfiguration.class, SecurityConfiguration.class})
     public static class TestConfiguration extends WebMvcConfigurationSupport {
-
         @Bean
         public MockMvc mvc(final WebApplicationContext context) {
             return MockMvcBuilders

--- a/problem-spring-webflux/src/test/java/org/zalando/problem/spring/webflux/advice/validation/BindAdviceTraitTest.java
+++ b/problem-spring-webflux/src/test/java/org/zalando/problem/spring/webflux/advice/validation/BindAdviceTraitTest.java
@@ -1,6 +1,9 @@
 package org.zalando.problem.spring.webflux.advice.validation;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.MediaType;
 import org.zalando.problem.Status;
 import org.zalando.problem.spring.common.MediaTypes;
@@ -12,7 +15,19 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
+import java.util.Locale;
+
 final class BindAdviceTraitTest implements AdviceTraitTesting {
+
+    @BeforeEach
+    void setUp() {
+        LocaleContextHolder.setLocale(Locale.ENGLISH);
+    }
+
+    @AfterEach
+    void tearDown() {
+        LocaleContextHolder.resetLocaleContext();
+    }
 
     @Test
     void invalidRequestQueryParams() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Set a fixed local for the tests

## Motivation and Context
Tests failed on my machine with a german locale:
```
[ERROR] invalidRequestBodyField  Time elapsed: 0.113 s  <<< FAILURE!
java.lang.AssertionError:

Expected: a string starting with "size must be between 3 and 10"
     but: was "Größe muss zwischen 3 und 10 sein"
	at org.zalando.problem.spring.webflux.advice.validation.BindAdviceTraitTest.invalidRequestBodyField(BindAdviceTraitTest.java:50)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
