### PR TITLE
Use @Configuration(proxyBeanMethods=false) to avoid unnecessary gener…

### DIFF
--- a/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/ProblemAutoConfiguration.java
+++ b/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/ProblemAutoConfiguration.java
@@ -12,7 +12,7 @@ import org.zalando.problem.spring.web.advice.AdviceTrait;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 @API(status = INTERNAL)
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnWebApplication
 @ConditionalOnClass(WebSecurityConfigurer.class)
 public class ProblemAutoConfiguration {

--- a/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/ProblemJacksonAutoConfiguration.java
+++ b/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/ProblemJacksonAutoConfiguration.java
@@ -16,7 +16,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
  * enabled.
  */
 @API(status = INTERNAL)
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnWebApplication
 @ConditionalOnMissingBean(ProblemJacksonWebMvcAutoConfiguration.class)
 public class ProblemJacksonAutoConfiguration {

--- a/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/ProblemJacksonWebMvcAutoConfiguration.java
+++ b/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/ProblemJacksonWebMvcAutoConfiguration.java
@@ -25,7 +25,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
  * deactivates {@link WebMvcAutoConfiguration}.
  */
 @API(status = INTERNAL)
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnWebApplication
 @ConditionalOnBean(WebMvcConfigurationSupport.class)
 @AutoConfigureBefore(WebMvcAutoConfiguration.class)

--- a/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemSecurityAutoConfiguration.java
+++ b/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemSecurityAutoConfiguration.java
@@ -27,7 +27,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 
 @API(status = INTERNAL)
 @AllArgsConstructor(onConstructor = @__(@Autowired))
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnWebApplication
 @ConditionalOnClass(WebSecurityConfigurer.class)
 @ConditionalOnBean(WebSecurityConfiguration.class)


### PR DESCRIPTION
…ation of cglib proxies.Cglib proxy creation can be an expensive operation.

Similar to spring-projects/spring-boot#9068

I think this is a breaking change if somebody calls methods on the configuration classes.