### PR TITLE
Add Customization Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ class for your [`@ControllerAdvice`](http://docs.spring.io/spring/docs/current/j
 
 ## Customization
 
-The problem handling process provided by `AdviceTrait` is built in a way that it allows for customization whenever the
-need arises. All of the following aspects can be overridden and tweaked:
+The problem handling process provided by `AdviceTrait` is built in a way that allows for customization whenever the
+need arises. All of the following aspects (and more) can be customized by implementing the appropriate advice trait interface:
 
 | Aspect              | Method(s)                   | Default                                                                                               |
 |---------------------|-----------------------------|-------------------------------------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ need arises. All of the following aspects can be overridden and tweaked:
 | Fallback            | `AdviceTrait.fallback(..)`  | `application/problem+json`                                                                            |
 | Post-Processing     | `AdviceTrait.process(..)`   | n/a                                                                                                   |
 
+The following example customizes the `MissingServletRequestParameterAdviceTrait` by adding a `parameter` extension field to the `Problem`:
+
+```java
+@ControllerAdvice
+public class MissingRequestParameterExceptionHandler implements MissingServletRequestParameterAdviceTrait {
+    @Override
+    public ProblemBuilder prepare(Throwable throwable, StatusType status, URI type) {
+        var exception = (MissingServletRequestParameterException) throwable;
+        return Problem.builder()
+                      .withTitle(status.getReasonPhrase())
+                      .withStatus(status)
+                      .withDetail(exception.getMessage())
+                      .with("parameter", exception.getParameterName());
+    }
+}
+```
+
 ## Usage
 
 Assuming there is a controller like this:


### PR DESCRIPTION
When first trying to use this library, I was confused on how the advice traits worked and how to customize them. I think an example would help tie everything together, so I added one to the README.

Note that the provided example does _not_ override one of the "aspects"/methods from the table in the README as I found it simpler to hook into the `prepare(..)` method. That's also why I added the "(and more)" bit.