### PR TITLE
Remove Spring Security class dependency on ProblemAutoConfiguration

### DIFF
--- a/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/ProblemAutoConfiguration.java
+++ b/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/ProblemAutoConfiguration.java
@@ -1,12 +1,10 @@
 package org.zalando.problem.spring.web.autoconfigure;
 
 import org.apiguardian.api.API;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
 import org.zalando.problem.spring.web.advice.AdviceTrait;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
@@ -14,7 +12,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 @API(status = INTERNAL)
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnWebApplication
-@ConditionalOnClass(WebSecurityConfigurer.class)
 public class ProblemAutoConfiguration {
 
     @Bean


### PR DESCRIPTION
## Description
0.26.0 changed the way how the default `ExceptionHandling` implementation is instantiated. As we have projects, which switched to Fabric Gateway for authentication and in consequence removed Spring Security dependencies, the latest version of the library does not work as in this case the class `WebSecurityConfigurer` is not available on the classpath.

## Motivation and Context
Fixes dependent projects not using Spring Security due to changes introduced in #413.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
