### PR TITLE
Register ExceptionHandling bean before WebMvcAutoConfiguration

### DIFF
--- a/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/ProblemAutoConfiguration.java
+++ b/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/ProblemAutoConfiguration.java
@@ -1,8 +1,10 @@
 package org.zalando.problem.spring.web.autoconfigure;
 
 import org.apiguardian.api.API;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.zalando.problem.spring.web.advice.AdviceTrait;
@@ -12,6 +14,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 @API(status = INTERNAL)
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnWebApplication
+@AutoConfigureBefore(WebMvcAutoConfiguration.class)
 public class ProblemAutoConfiguration {
 
     @Bean


### PR DESCRIPTION
## Description
The fix, which I provided in #513 is not sufficient enough. While it registers the `ExceptionHandling` as bean, it is already to late for Spring's `ExceptionHandlerExceptionResolver` class to pick it up.

## Motivation and Context
The change makes auto configuration work again as expected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
