### PR TITLE
Fix spring-security configuration for webmvc

### DIFF
--- a/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemHttpConfigurer.java
+++ b/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemHttpConfigurer.java
@@ -1,7 +1,7 @@
 package org.zalando.problem.spring.web.autoconfigure.security;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.BeanInstantiationException;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -19,13 +19,15 @@ public class ProblemHttpConfigurer extends AbstractHttpConfigurer<ProblemHttpCon
             return;
         }
         final ObjectProvider<SecurityProblemSupport> provider = applicationContext.getBeanProvider(SecurityProblemSupport.class);
-        provider.ifAvailable(support -> {
-            try {
-                http.exceptionHandling().authenticationEntryPoint(support).accessDeniedHandler(support);
-            } catch (final Exception cause) {
-                throw new BeanInstantiationException(getClass(), "Fail to register HttpSecurity's exceptionHandling", cause);
-            }
-            log.info("ProblemHttpConfigurer register HttpSecurity's exceptionHandling");
-        });
+        provider.ifAvailable(support -> register(http, support));
+    }
+
+    private void register(final HttpSecurity http, final SecurityProblemSupport support) {
+        try {
+            http.exceptionHandling().authenticationEntryPoint(support).accessDeniedHandler(support);
+        } catch (final Exception cause) {
+            throw new BeanCreationException("Fail to register HttpSecurity's exceptionHandling", cause);
+        }
+        log.info("Register HttpSecurity's exceptionHandling");
     }
 }

--- a/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemHttpConfigurer.java
+++ b/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemHttpConfigurer.java
@@ -1,0 +1,31 @@
+package org.zalando.problem.spring.web.autoconfigure.security;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeanInstantiationException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
+
+@Slf4j
+public class ProblemHttpConfigurer extends AbstractHttpConfigurer<ProblemHttpConfigurer, HttpSecurity> {
+
+    @Override
+    public void init(final HttpSecurity http) {
+        final ApplicationContext applicationContext = http.getSharedObject(ApplicationContext.class);
+        if (applicationContext == null) {
+            log.warn("HttpSecurity's SharedObject doesn't have ApplicationContext");
+            return;
+        }
+        final ObjectProvider<SecurityProblemSupport> provider = applicationContext.getBeanProvider(SecurityProblemSupport.class);
+        provider.ifAvailable(support -> {
+            try {
+                http.exceptionHandling().authenticationEntryPoint(support).accessDeniedHandler(support);
+            } catch (final Exception cause) {
+                throw new BeanInstantiationException(getClass(), "Fail to register HttpSecurity's exceptionHandling", cause);
+            }
+            log.info("ProblemHttpConfigurer register HttpSecurity's exceptionHandling");
+        });
+    }
+}

--- a/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemSecurityAutoConfiguration.java
+++ b/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemSecurityAutoConfiguration.java
@@ -1,23 +1,20 @@
 package org.zalando.problem.spring.web.autoconfigure.security;
 
-import lombok.AllArgsConstructor;
 import org.apiguardian.api.API;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.zalando.problem.spring.web.advice.AdviceTrait;
 import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
 import org.zalando.problem.spring.web.autoconfigure.ProblemAutoConfiguration;
@@ -25,26 +22,14 @@ import org.zalando.problem.spring.web.autoconfigure.ProblemAutoConfiguration;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 @API(status = INTERNAL)
-@AllArgsConstructor
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnWebApplication
+@ConditionalOnWebApplication(type = Type.SERVLET)
 @ConditionalOnClass(WebSecurityConfigurer.class)
 @ConditionalOnBean(WebSecurityConfiguration.class)
 @Import(SecurityProblemSupport.class)
-//subtract random, uncommon number to reduce chances of collision with a user-selected order
-@Order(Ordered.LOWEST_PRECEDENCE - 21)
 @AutoConfigureAfter(SecurityAutoConfiguration.class)
 @AutoConfigureBefore(ProblemAutoConfiguration.class)
-public class ProblemSecurityAutoConfiguration extends WebSecurityConfigurerAdapter {
-
-    private final SecurityProblemSupport support;
-
-    @Override
-    public void configure(final HttpSecurity http) throws Exception {
-        http.exceptionHandling()
-                .authenticationEntryPoint(support)
-                .accessDeniedHandler(support);
-    }
+public class ProblemSecurityAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(AdviceTrait.class)
@@ -52,4 +37,8 @@ public class ProblemSecurityAutoConfiguration extends WebSecurityConfigurerAdapt
         return new SecurityExceptionHandling();
     }
 
+    @Bean
+    public ProblemSecurityBeanPostProcessor problemSecurityBeanPostProcessor(final ObjectProvider<SecurityProblemSupport> securityProblemSupport) {
+        return new ProblemSecurityBeanPostProcessor(securityProblemSupport);
+    }
 }

--- a/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemSecurityBeanPostProcessor.java
+++ b/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemSecurityBeanPostProcessor.java
@@ -1,0 +1,31 @@
+package org.zalando.problem.spring.web.autoconfigure.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.util.ClassUtils;
+import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
+
+@RequiredArgsConstructor
+public class ProblemSecurityBeanPostProcessor implements BeanPostProcessor {
+    private final ObjectProvider<SecurityProblemSupport> securityProblemSupport;
+
+    @Override
+    public Object postProcessAfterInitialization(final Object bean, final String beanName) throws BeansException {
+        if (ClassUtils.isAssignableValue(HttpSecurity.class, bean)) {
+            securityProblemSupport.ifAvailable(support -> register((HttpSecurity) bean, beanName, support));
+        }
+        return bean;
+    }
+
+    private void register(final HttpSecurity http, final String beanName, final SecurityProblemSupport support) {
+        try {
+            http.exceptionHandling().authenticationEntryPoint(support).accessDeniedHandler(support);
+        } catch (final Exception cause) {
+            throw new BeanCreationException(beanName, cause);
+        }
+    }
+}

--- a/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemSecurityBeanPostProcessor.java
+++ b/problem-spring-web-autoconfigure/src/main/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemSecurityBeanPostProcessor.java
@@ -1,6 +1,7 @@
 package org.zalando.problem.spring.web.autoconfigure.security;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.ObjectProvider;
@@ -9,6 +10,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.util.ClassUtils;
 import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
 
+@Slf4j
 @RequiredArgsConstructor
 public class ProblemSecurityBeanPostProcessor implements BeanPostProcessor {
     private final ObjectProvider<SecurityProblemSupport> securityProblemSupport;
@@ -27,5 +29,6 @@ public class ProblemSecurityBeanPostProcessor implements BeanPostProcessor {
         } catch (final Exception cause) {
             throw new BeanCreationException(beanName, cause);
         }
+        log.info("Register HttpSecurity's exceptionHandling");
     }
 }

--- a/problem-spring-web-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/problem-spring-web-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -3,3 +3,6 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   org.zalando.problem.spring.web.autoconfigure.ProblemJacksonWebMvcAutoConfiguration, \
   org.zalando.problem.spring.web.autoconfigure.ProblemJacksonAutoConfiguration, \
   org.zalando.problem.spring.web.autoconfigure.security.ProblemSecurityAutoConfiguration
+
+org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer=\
+  org.zalando.problem.spring.web.autoconfigure.security.ProblemHttpConfigurer

--- a/problem-spring-web-autoconfigure/src/test/java/org/zalando/problem/spring/web/autoconfigure/security/NoConfigurerSecurityTest.java
+++ b/problem-spring-web-autoconfigure/src/test/java/org/zalando/problem/spring/web/autoconfigure/security/NoConfigurerSecurityTest.java
@@ -1,0 +1,35 @@
+package org.zalando.problem.spring.web.autoconfigure.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DirtiesContext
+final class NoConfigurerSecurityTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldConfigureExceptionHandling() throws Exception {
+        mockMvc.perform(get("/not-exists-url"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status", is(401)))
+                .andExpect(jsonPath("$.title", is("Unauthorized")))
+                .andExpect(jsonPath("$.detail", is("Full authentication is required to access this resource")));
+    }
+
+    @SpringBootApplication
+    static class TestApp {
+    }
+}

--- a/problem-spring-web-autoconfigure/src/test/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemHttpConfigurerTest.java
+++ b/problem-spring-web-autoconfigure/src/test/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemHttpConfigurerTest.java
@@ -1,0 +1,93 @@
+package org.zalando.problem.spring.web.autoconfigure.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.support.SpringFactoriesLoader;
+import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.ClassUtils;
+import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ProblemHttpConfigurerTest {
+
+    private ProblemHttpConfigurer configurer;
+    private Map<Class<?>, Object> sharedObjects;
+    private ApplicationContext applicationContext;
+    private ObjectPostProcessor<Object> objectPostProcessor;
+    private AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        configurer = new ProblemHttpConfigurer();
+        sharedObjects = new HashMap<>();
+        applicationContext = mock(ApplicationContext.class);
+        objectPostProcessor = mock(ObjectPostProcessor.class);
+        authenticationManagerBuilder = mock(AuthenticationManagerBuilder.class);
+    }
+
+    @Test
+    void shouldBeRegisteredSpringFactoriesLoader() {
+        assertThat(SpringFactoriesLoader.loadFactories(AbstractHttpConfigurer.class, ClassUtils.getDefaultClassLoader()))
+                .hasAtLeastOneElementOfType(ProblemHttpConfigurer.class);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldBeConfigured() throws Exception {
+        sharedObjects.put(ApplicationContext.class, applicationContext);
+        final SecurityProblemSupport securityProblemSupport = mock(SecurityProblemSupport.class);
+        final ObjectProvider<SecurityProblemSupport> beanProvider = mock(ObjectProvider.class);
+        doReturn(beanProvider).when(applicationContext).getBeanProvider(SecurityProblemSupport.class);
+        doAnswer(answer -> {
+            final Consumer<SecurityProblemSupport> consumer = (Consumer<SecurityProblemSupport>) answer.getArguments()[0];
+            consumer.accept(securityProblemSupport);
+            return null;
+        }).when(beanProvider).ifAvailable(any(Consumer.class));
+        final HttpSecurity http = new HttpSecurity(objectPostProcessor, authenticationManagerBuilder, sharedObjects);
+
+        configurer.init(http);
+
+        assertThat(ReflectionTestUtils.getField(http.exceptionHandling(), "authenticationEntryPoint")).isEqualTo(securityProblemSupport);
+        assertThat(ReflectionTestUtils.getField(http.exceptionHandling(), "accessDeniedHandler")).isEqualTo(securityProblemSupport);
+    }
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldBeNotConfiguredWhenSecurityProblemSupportNotExists() throws Exception {
+        sharedObjects.put(ApplicationContext.class, applicationContext);
+        final ObjectProvider<SecurityProblemSupport> beanProvider = mock(ObjectProvider.class);
+        doReturn(beanProvider).when(applicationContext).getBeanProvider(SecurityProblemSupport.class);
+        doReturn(null).when(beanProvider).getIfAvailable();
+        final HttpSecurity http = new HttpSecurity(objectPostProcessor, authenticationManagerBuilder, sharedObjects);
+
+        configurer.init(http);
+
+        assertThat(ReflectionTestUtils.getField(http.exceptionHandling(), "authenticationEntryPoint")).isEqualTo(null);
+        assertThat(ReflectionTestUtils.getField(http.exceptionHandling(), "accessDeniedHandler")).isEqualTo(null);
+    }
+
+    @Test
+    void shouldBeNotConfiguredWhenApplicationContextNotExists() throws Exception {
+        final HttpSecurity http = new HttpSecurity(objectPostProcessor, authenticationManagerBuilder, sharedObjects);
+
+        configurer.init(http);
+
+        assertThat(ReflectionTestUtils.getField(http.exceptionHandling(), "authenticationEntryPoint")).isEqualTo(null);
+        assertThat(ReflectionTestUtils.getField(http.exceptionHandling(), "accessDeniedHandler")).isEqualTo(null);
+    }
+}

--- a/problem-spring-web-autoconfigure/src/test/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemSecurityAutoConfigurationTest.java
+++ b/problem-spring-web-autoconfigure/src/test/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemSecurityAutoConfigurationTest.java
@@ -1,0 +1,74 @@
+package org.zalando.problem.spring.web.autoconfigure.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.zalando.problem.spring.web.advice.AdviceTrait;
+import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
+import org.zalando.problem.spring.web.autoconfigure.ProblemAutoConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ProblemSecurityAutoConfigurationTest {
+    WebApplicationContextRunner contextRunner;
+
+    @BeforeEach
+    void setUp() {
+        contextRunner = new WebApplicationContextRunner()
+                .withConfiguration(
+                        AutoConfigurations.of(ProblemSecurityAutoConfiguration.class,
+                                ProblemAutoConfiguration.class,
+                                SecurityAutoConfiguration.class));
+    }
+
+    @Test
+    void shouldBeConfiguredDefaults() {
+        contextRunner.withUserConfiguration(SecurityConfiguration.class)
+                .run(context -> assertThat(context)
+                        .hasSingleBean(SecurityProblemSupport.class)
+                        .hasSingleBean(AdviceTrait.class)
+                        .hasSingleBean(SecurityExceptionHandling.class)
+                        .hasSingleBean(ProblemSecurityBeanPostProcessor.class));
+    }
+
+    @Test
+    void shouldBeConfiguredWithWebSecurityConfigurerAdapter() {
+        contextRunner.withUserConfiguration(WebSecurityConfigurerAdapterConfiguration.class)
+                .run(context -> assertThat(context)
+                        .hasSingleBean(SecurityProblemSupport.class)
+                        .hasSingleBean(AdviceTrait.class)
+                        .hasSingleBean(SecurityExceptionHandling.class)
+                        .hasSingleBean(ProblemSecurityBeanPostProcessor.class));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class SecurityConfiguration {
+        @Bean
+        HandlerExceptionResolver handlerExceptionResolver() {
+            return mock(HandlerExceptionResolver.class);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class WebSecurityConfigurerAdapterConfiguration {
+        @Bean
+        HandlerExceptionResolver handlerExceptionResolver() {
+            return mock(HandlerExceptionResolver.class);
+        }
+
+        @Configuration
+        static class SecurityConfig extends WebSecurityConfigurerAdapter {
+            @Override
+            public void configure(final HttpSecurity http) {
+            }
+        }
+    }
+}

--- a/problem-spring-web-autoconfigure/src/test/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemSecurityBeanPostProcessorTest.java
+++ b/problem-spring-web-autoconfigure/src/test/java/org/zalando/problem/spring/web/autoconfigure/security/ProblemSecurityBeanPostProcessorTest.java
@@ -1,0 +1,56 @@
+package org.zalando.problem.spring.web.autoconfigure.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
+
+import java.util.HashMap;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+
+class ProblemSecurityBeanPostProcessorTest {
+
+    private ObjectProvider<SecurityProblemSupport> provider;
+    private ProblemSecurityBeanPostProcessor processor;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        provider = mock(ObjectProvider.class);
+        processor = new ProblemSecurityBeanPostProcessor(provider);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldBeConfigured() throws Exception {
+        final ObjectPostProcessor<Object> objectPostProcessor = mock(ObjectPostProcessor.class);
+        final AuthenticationManagerBuilder authenticationManagerBuilder = mock(AuthenticationManagerBuilder.class);
+        final SecurityProblemSupport securityProblemSupport = mock(SecurityProblemSupport.class);
+        final HttpSecurity http = new HttpSecurity(objectPostProcessor, authenticationManagerBuilder, new HashMap<>());
+
+        doAnswer(answer -> {
+            final Consumer<SecurityProblemSupport> consumer = (Consumer<SecurityProblemSupport>) answer.getArguments()[0];
+            consumer.accept(securityProblemSupport);
+            return null;
+        }).when(provider).ifAvailable(any(Consumer.class));
+
+        assertThat(processor.postProcessAfterInitialization(http, "httpSecurity")).isEqualTo(http);
+        assertThat(ReflectionTestUtils.getField(http.exceptionHandling(), "authenticationEntryPoint")).isEqualTo(securityProblemSupport);
+        assertThat(ReflectionTestUtils.getField(http.exceptionHandling(), "accessDeniedHandler")).isEqualTo(securityProblemSupport);
+    }
+
+    @Test
+    void shouldBeNotConfiguredWhenBeanIsNotHttpSecurity() {
+        assertThat(processor.postProcessAfterInitialization("test", "notHttpSecurity")).isEqualTo("test");
+    }
+}

--- a/problem-spring-web-autoconfigure/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/problem-spring-web-autoconfigure/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Description
When spring security configuration with `WebSecurityConfigurerAdapter`, then throw IllegalStateException with message(`Found WebSecurityConfigurerAdapter as well as SecurityFilterChain. Please select just one`)
`WebSecurityConfigurerAdapter` loaded  `spring.factories` file when default security configuration. Add `ProblemHttpConfigur`, Using this meachnism is solved that problem.
But, If not using `WebSecurityConfigurerAdapter`, `spring.factories` is not working. so added `ProblemSecurityBeanPostProcessor` will be configure exception handling

## Motivation and Context
This fixes #501, #573 and also resolves #582

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
