### PR TITLE
fix(sec): upgrade org.springframework.security:spring-security-web to 5.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <jackson.version>2.13.2</jackson.version>
         <problem.version>0.27.1</problem.version>
         <spring.version>5.3.16</spring.version>
-        <spring-security.version>5.6.2</spring-security.version>
+        <spring-security.version>5.6.4</spring-security.version>
         <spring-boot.version>2.6.4</spring-boot.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <javax-el.version>3.0.0</javax-el.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework.security:spring-security-web 5.6.2
- [CVE-2022-22978](https://www.oscs1024.com/hd/CVE-2022-22978)


### What did I do？
Upgrade org.springframework.security:spring-security-web from 5.6.2 to 5.6.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS