### PR TITLE
Add instructions when existing ControllerAdvice and update config path

### DIFF
--- a/problem-spring-web/README.md
+++ b/problem-spring-web/README.md
@@ -83,15 +83,14 @@ class ExceptionHandling implements ProblemHandling {
 }
 ```
 
+Check if you already have a ControllerAdvice. In this case you might want to adjust your code to solely rely on this library, or set a `@Order(Ordered.HIGHEST_PRECEDENCE)` in your existing Advice for specific exceptions and leave the others for the library to handle.
+
 The [`NoHandlerFoundAdviceTrait`](src/main/java/org/zalando/problem/spring/web/advice/routing/NoHandlerFoundAdviceTrait.java)
 in addition also requires the following configuration:
 
 ```yaml
-spring:
-  resources:
-    add-mappings: false
-  mvc:
-    throw-exception-if-no-handler-found: true
+spring.web.resources.add-mappings=false
+spring.mvc.throw-exception-if-no-handler-found=true
 ```
 
 If you're using Spring Boot, make sure you disable the `ErrorMvcAutoConfiguration`:


### PR DESCRIPTION
## Description
This PR introduces a section in the Spring MVC installation README.md regarding the situation when there is an existing ControllerAdvice. Additionally I've updated the application.properties config path which was outdated.

This PR refers to an issue I've opened some time back - https://github.com/zalando/problem-spring-web/issues/777

## Motivation and Context
Many existing applications already use a ControllerAdvice and it's quite easy to forget about it. The motivation for this PR came from facing this problem myself.

## Types of changes
- [x] Documentation update

## Checklist:
- [x] I have updated the documentation accordingly.
