### PR TITLE
Mark jackson-datatype-problem dependency as not optional

### DIFF
--- a/problem-spring-web-autoconfigure/pom.xml
+++ b/problem-spring-web-autoconfigure/pom.xml
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>org.zalando</groupId>
             <artifactId>jackson-datatype-problem</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Description
The latest release defines the `jackson-datatype-problem` dependency as optional, which leads to library users having to explicitly declare it. Given that 0.28.0 is a minor release, we should keep the existing behaviour and always add it when the `problem-spring-web-autoconfigure` dependency is directly or transitively used given that the current `AutoConfiguration` classes do not have a `ConditionalOnBean` annotation to only execute them when the `ProblemModule` is available on the classpath.

## Motivation and Context
By removing the `<optional>` tag again, the dependency tree is changed to pull the dependency again in.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)