### PR TITLE
Added jackson-datatype-problem as Javadoc dependency

### DIFF
--- a/problem-violations/pom.xml
+++ b/problem-violations/pom.xml
@@ -58,4 +58,21 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalDependencies>
+                        <additionalDependency>
+                            <groupId>org.zalando</groupId>
+                            <artifactId>jackson-datatype-problem</artifactId>
+                            <version>${problem.version}</version>
+                        </additionalDependency>
+                    </additionalDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
## Description
Fixes the issue when generating the Javadocs for problem-violations by adding the jackson-datatype-problem dependency during the execution of the goal.