### PR TITLE
Update example how to configure NoHandlerAdviceTrait

### DIFF
--- a/problem-spring-web/README.md
+++ b/problem-spring-web/README.md
@@ -93,8 +93,9 @@ in addition also requires the following configuration:
 
 ```yaml
 spring:
-  resources:
-    add-mappings: false
+  web:
+    resources:
+      add-mappings: false
   mvc:
     throw-exception-if-no-handler-found: true
 ```


### PR DESCRIPTION
Incorporates the changes from #874. Given that we now only support Spring Boot 3+, there is no need to mention the deprecated configuration anymore.