### PR TITLE
Pick status code from `ErrorResponse` interfaces

### DIFF
--- a/problem-spring-common/src/test/java/org/zalando/problem/spring/common/AdviceTraitTest.java
+++ b/problem-spring-common/src/test/java/org/zalando/problem/spring/common/AdviceTraitTest.java
@@ -2,7 +2,10 @@ package org.zalando.problem.spring.common;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
@@ -26,6 +29,24 @@ class AdviceTraitTest {
     class TestException extends RuntimeException {
         public TestException(String message) {
             super(message);
+        }
+    }
+
+    class SpringExpception extends Throwable implements ErrorResponse {
+        final HttpStatus status;
+
+        SpringExpception(HttpStatus status) {
+            this.status = status;
+        }
+
+        @Override
+        public HttpStatusCode getStatusCode() {
+            return status;
+        }
+
+        @Override
+        public ProblemDetail getBody() {
+            return ProblemDetail.forStatusAndDetail(status, status.getReasonPhrase());
         }
     }
 
@@ -53,6 +74,16 @@ class AdviceTraitTest {
         assertThat(result.getStatus().getStatusCode(), is(205));
         assertThat(result.getType().toString(), is("about:blank"));
         assertThat(result.getTitle(), is("Reset Content"));
+        assertThat(result.getDetail(), is("Message"));
+    }
+
+    @Test
+    void buildsOnErrorResponseThrowable() {
+        final Problem result = unit.toProblem(new SpringExpception(HttpStatus.NOT_FOUND));
+
+        assertThat(result.getStatus().getStatusCode(), is(404));
+        assertThat(result.getType().toString(), is("about:blank"));
+        assertThat(result.getTitle(), is("Not Found"));
         assertThat(result.getDetail(), is("Message"));
     }
 

--- a/problem-spring-common/src/test/java/org/zalando/problem/spring/common/AdviceTraitTest.java
+++ b/problem-spring-common/src/test/java/org/zalando/problem/spring/common/AdviceTraitTest.java
@@ -84,7 +84,6 @@ class AdviceTraitTest {
         assertThat(result.getStatus().getStatusCode(), is(404));
         assertThat(result.getType().toString(), is("about:blank"));
         assertThat(result.getTitle(), is("Not Found"));
-        assertThat(result.getDetail(), is("Message"));
     }
 
     @Test


### PR DESCRIPTION
Unhandled exceptions that extend spring-boot's `ErrorResponse` have a status code defined and we should use that instead of forcing it to be `500`

## Description
Adding `problem-spring-web` to your project has a consequence of turning exceptions which haven't been explicitly handled into `500`s. While at face value this may seem like a reasonable default behaviour, one should take into consideration that spring-boot can throw errors internally which have status codes attached to them, so it's only fair that `problem` should listen to those and pass them forwards.

## Motivation and Context
Adding `problem-spring-web` to a bare spring-boot project and extending from `ProblemHandling` causes errors to turn into `500`s. For example, calling an endpoint that doesn't exist results in `500 Resource not found` instead of `404 Resource not found` which is the default and expected behaviour.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
