### PR TITLE
Add `shouldLog` to better control logging spam

### DIFF
--- a/problem-spring-web/src/main/java/org/zalando/problem/spring/web/advice/AdviceTrait.java
+++ b/problem-spring-web/src/main/java/org/zalando/problem/spring/web/advice/AdviceTrait.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.server.ResponseStatusException;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
 import org.zalando.problem.StatusType;
@@ -164,11 +165,16 @@ public interface AdviceTrait extends org.zalando.problem.spring.common.AdviceTra
                 })), request);
     }
 
+    default boolean shouldLog(final Throwable throwable) {
+        return !(throwable instanceof ResponseStatusException) && !(throwable instanceof Problem);
+    }
+
     default void log(
             final Throwable throwable,
             @SuppressWarnings("UnusedParameters") final Problem problem,
             @SuppressWarnings("UnusedParameters") final NativeWebRequest request,
             final HttpStatus status) {
+        if (!this.shouldLog(throwable)) return;
         AdviceTraits.log(throwable, status);
     }
 


### PR DESCRIPTION
Currently, adding the `problem-spring-web` package will result in any exception that isn't explicitly handled to be logged in full (stack trace and all) and with no obvious way to stop it. While this may seem like a good idea, a common trope of handling expected errors is to throw a `Problem` or a `ResponseStatusException` after some validation step. For example:

```kotlin
@GetMapping("/route")
fun myRoute(@RequestHeader("X-Custom-Header") customHeader: String) {
  if (customHeader != "fixed-value") {
    throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid X-Custom-Header")
  }

  // happy path
}
```

Doing so while having `problem-spring-web` active will result in the hole stack-trace of `ResponseStatusException` to be logged.

This behaviour can be stopped by overriding the `log(...)` method in `ProblemHandling` but I'd argue that's not very obvious nor very clean. Thus, my proposed solution is adding a `shouldLog(...)` function which can then be overriden.

I chose to add the default behaviour of not logging `ResponseStatusException` or `Problem` as I believe those are pretty commonly thrown in situations where having the whole stack-trace printed isn't needed. Though I can agree with the argument that this would be a backwards incompatible change and therefore don't feel very strongly about it. Let me know and I can remove it and leave the implementation as `return true;` instead.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
