### PR TITLE
Adding jaxb-api dependency to address coveralls-maven-plugin error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -447,6 +447,13 @@
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.3.0</version>
+		<dependencies>
+                    <dependency>
+                        <artifactId>jaxb-api</artifactId>
+                        <groupId>javax.xml.bind</groupId>
+                        <version>2.3.1</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
## Description
Adds jaxb-api as dependency to address build error:

```
[ERROR] Failed to execute goal org.eluder.coveralls:coveralls-maven-plugin:4.3.0:report (default-cli) on project solid: Execution default-cli of goal org.eluder.coveralls:coveralls-maven-plugin:4.3.0:report failed: A required class was missing while executing org.eluder.coveralls:coveralls-maven-plugin:4.3.0:report: javax/xml/bind/DatatypeConverter
```

## Motivation and Context
https://github.com/trautonen/coveralls-maven-plugin/issues/141

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
