### PR TITLE
Fixes build warnings

### DIFF
--- a/problem-spring-webflux/pom.xml
+++ b/problem-spring-webflux/pom.xml
@@ -82,11 +82,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-config</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>

--- a/problem-violations/pom.xml
+++ b/problem-violations/pom.xml
@@ -62,7 +62,9 @@
     <build>
         <plugins>
             <plugin>
+		<groupId>org.apache.maven.plugin</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+		<version>3.5.0</version>
                 <configuration>
                     <additionalDependencies>
                         <additionalDependency>


### PR DESCRIPTION
## Description
Closes #969 

## Motivation and Context
- `spring-security-config` was declared as dependency twice leading to build warnings.
- `maven-javadoc-plugin` did not have a version defined leading to build warnings.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
